### PR TITLE
Adding "relative mode" to OnScreenStick

### DIFF
--- a/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
+++ b/Packages/com.unity.inputsystem/InputSystem/Plugins/OnScreen/OnScreenStick.cs
@@ -13,9 +13,20 @@ namespace UnityEngine.InputSystem.Plugins.OnScreen
     [AddComponentMenu("Input/On-Screen Stick")]
     public class OnScreenStick : OnScreenControl, IPointerDownHandler, IPointerUpHandler, IDragHandler
     {
+        
+        public bool relativeMode;
+         
         public void OnPointerDown(PointerEventData data)
         {
-            RectTransformUtility.ScreenPointToLocalPointInRectangle(transform.parent.GetComponentInParent<RectTransform>(), data.position, data.pressEventCamera, out m_PointerDownPos);
+            if (relativeMode)
+                {
+                    RectTransformUtility.ScreenPointToLocalPointInRectangle(transform.parent.GetComponentInParent<RectTransform>(), data.position, data.pressEventCamera, out m_PointerDownPos);
+                }
+                else
+                {
+                    m_PointerDownPos = Vector2.zero;
+                    OnDrag(data);
+                }        
         }
 
         public void OnDrag(PointerEventData data)


### PR DESCRIPTION
Currently, the controller uses your first touch to determine a "start point". In many cases its actually helpful to always have the "start point" at the center. 
Scenario, if I tap right on the controller, currently this would not register any movement because the origin of the movement is reset to this point. Ideally if I tap right, I would expect the controller to register this tap as being on the right side of the controller.
I think this should be the default behaviour, please let me know your thoughts.
Thanks!!